### PR TITLE
ALI-22946: ember-tag-input

### DIFF
--- a/addon/components/tag-input.hbs
+++ b/addon/components/tag-input.hbs
@@ -1,5 +1,5 @@
 {{#each this.tags as |tag index|~}}
-  <li class="emberTagInput-tag">
+  <li class="emberTagInput-tag {{tag.modifiers}}">
     {{yield tag}}
     {{#if this._isRemoveButtonVisible}}
       <a class="emberTagInput-remove" {{on 'click' (fn this.removeTag index)}}></a>

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -21,10 +21,8 @@
 }
 
 .emberTagInput-tag {
-  background: cornflowerblue;
   border-radius: 20px;
   margin-right: 5px;
-  color: white;
 }
 
 .emberTagInput-tag--remove {

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -21,8 +21,10 @@
 }
 
 .emberTagInput-tag {
+  background: cornflowerblue;
   border-radius: 20px;
   margin-right: 5px;
+  color: white;
 }
 
 .emberTagInput-tag--remove {


### PR DESCRIPTION
Contribution guide: https://github.com/calvinlough/ember-tag-input/blob/0ff659978c6dfac46500faae37f7511044831c8e/CONTRIBUTING.md

TL;DR: Pulled down a fork of ember-tag-input and updated https://github.com/calvinlough/ember-tag-input/pull/221 to get on top of the current master

Since there's a chance that even with the updates the PR will stay in stasis forever, and just to get more on eyes on it before I submit it to the main repo, thought I'd ask y'all to take a look.

The only actual change is that one line in tag-input, the rest is test/doc updating.

A corresponding ALI PR will come out soon (TM).